### PR TITLE
feat(vue 3): migrate from Vue.default.version to a fallback

### DIFF
--- a/src/util/createInstantSearchComponent.js
+++ b/src/util/createInstantSearchComponent.js
@@ -1,7 +1,7 @@
 import { createSuitMixin } from '../mixins/suit';
 import { version } from '../../package.json'; // rollup does pick only what needed from json
 import { _objectSpread } from './polyfills';
-import Vue from 'vue';
+import * as Vue from 'vue';
 
 export const createInstantSearchComponent = component =>
   _objectSpread(
@@ -38,7 +38,9 @@ export const createInstantSearchComponent = component =>
       created() {
         const searchClient = this.instantSearchInstance.client;
         if (typeof searchClient.addAlgoliaAgent === 'function') {
-          searchClient.addAlgoliaAgent(`Vue (${Vue.version})`);
+          searchClient.addAlgoliaAgent(
+            `Vue (${Vue.version || Vue.default.version})`
+          );
           searchClient.addAlgoliaAgent(`Vue InstantSearch (${version})`);
         }
       },


### PR DESCRIPTION
In Vue 3 `version` is an explicit export, while in Vue 2 it's a property of the default export.

This way _does_ give a warning ⚠️ when using Vue 2: `"export 'version' (imported as 'A') was not found in 'vue'`. I'm not too sure how to avoid that